### PR TITLE
調整 3D Model 切版更適合 Mobile UI

### DIFF
--- a/src/components/HeroModels/Computer.tsx
+++ b/src/components/HeroModels/Computer.tsx
@@ -1,9 +1,7 @@
-import React from 'react'
 import { useGLTF } from '@react-three/drei'
-// import * as THREE from 'three'
-import type { GLTFResult } from '../../types/type'
+import type { ComputerProps, GLTFResult } from '../../types/type'
 
-const Computer: React.FC = () => {
+const Computer = ({ isMobile }: ComputerProps) => {
   const computer = useGLTF("./desktop_pc/scene.gltf") as unknown as GLTFResult
 
   return (
@@ -20,8 +18,8 @@ const Computer: React.FC = () => {
       />
       <primitive
         object={computer.scene}
-        scale={0.75}
-        position={[0, -4.25, -1.5]}
+        scale={isMobile ? 0.55 : 0.75}
+        position={isMobile ? [0, -3, -1.7] : [0, -4.25, -1.5]}
         rotation={[0.01, -0.2, -0.1]}
       />
     </mesh>

--- a/src/components/HeroModels/HeroPC.tsx
+++ b/src/components/HeroModels/HeroPC.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react'
+import React, { Suspense, useEffect, useState } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls, Preload } from '@react-three/drei'
 import HeroLoader from './HeroLoader'
@@ -6,6 +6,28 @@ import Computer  from './Computer'
 import Particles from './Particles'
 
 const HeroPC: React.FC = () => {
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    // Add a listener for changes to the screen size
+    const mediaQuery = window.matchMedia("(max-width: 500px)")
+
+    // Set the initial value of the `isMobile` state variable
+    setIsMobile(mediaQuery.matches)
+
+    // Define a callback function to handle changes to the media query
+    const handleMediaQueryChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches)
+    }
+
+    // Add the callback function as a listener for changes to the media query
+    mediaQuery.addEventListener("change", handleMediaQueryChange)
+
+    // Remove the listener when the component is unmounted
+    return () => {
+      mediaQuery.removeEventListener("change", handleMediaQueryChange)
+    }
+  }, [])
 
   return (
     <>
@@ -21,7 +43,7 @@ const HeroPC: React.FC = () => {
             minPolarAngle={Math.PI / 2}
             maxPolarAngle={Math.PI / 2}
           />
-          <Computer />
+          <Computer isMobile={isMobile} />
         </Suspense>
 
         <Preload all />

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -80,3 +80,7 @@ export type SocialImg = {
   name: string
   imgPath: string
 }
+
+export type ComputerProps = {
+  isMobile: boolean
+}


### PR DESCRIPTION
## 背景描述 (Why)

此 PR 旨在優化 3D 電腦模型在移動裝置上的顯示效果。原先的 3D 模型在小螢幕上可能因尺寸或位置未調整而導致使用者體驗不佳。本次修改解決了模型在不同螢幕尺寸下的適應性問題，確保在行動裝置上也能有良好的視覺呈現。

## 實作方法 (How)

本次實作主要透過以下方式達成響應式調整：

1.  **狀態管理與螢幕偵測**：在 `HeroPC.tsx` 組件中，引入 `useState` 和 `useEffect` Hooks。透過 `window.matchMedia("(max-width: 500px)")` API 來偵測當前視窗寬度是否小於或等於 500px，並將結果（`true` 或 `false`）存儲在 `isMobile` 狀態中。同時，添加了事件監聽器以響應螢幕尺寸的動態變化，並在組件卸載時移除監聽器以防止內存洩漏。
2.  **Props 傳遞**：將 `isMobile` 狀態作為 prop 傳遞給 `Computer.tsx` 子組件。
3.  **條件渲染模型屬性**：在 `Computer.tsx` 組件中，接收 `isMobile` prop。根據 `isMobile` 的值，動態調整 `<primitive>` 物件的 `scale`（縮放比例）和 `position`（位置）屬性。
    * 在移動裝置上 (isMobile === true)，模型縮放比例設為 `0.55`，位置設為 `[0, -3, -1.7]`。
    * 在桌面裝置上 (isMobile === false)，模型縮放比例設為 `0.75`，位置設為 `[0, -4.25, -1.5]`。
4.  **類型定義**：在 `src/types/type.ts` 中新增 `ComputerProps` 類型，明確定義 `Computer` 組件接收的 `isMobile` prop 為布林值，增強了程式碼的型別安全。

## 實際變更（做了什麼）

- [ ] **響應式 3D 模型調整 (`Computer.tsx`)**
    - 修改 `Computer` 組件以接收 `isMobile: boolean` prop。
    - 根據 `isMobile` prop 的值，條件性地調整 3D 模型的 `scale` 和 `position`，使其在小螢幕上有更合適的顯示。

- [ ] **移動裝置偵測邏輯 (`HeroPC.tsx`)**
    - 在 `HeroPC` 組件中使用 `useState` 和 `useEffect` 結合 `window.matchMedia` 實現了對螢幕寬度是否小於等於 500px 的偵測。
    - 將偵測到的 `isMobile` 狀態傳遞給 `Computer` 組件，以驅動模型的響應式變化。

- [ ] **新增類型定義 (`src/types/type.ts`)**
    - 添加了 `ComputerProps` 類型，用於定義 `Computer` 組件的 props，提高程式碼的可維護性和 robustness。

### 測試驗證

- [ ] **桌面端視圖驗證**：
    - 在瀏覽器視窗寬度大於 500px 時，驗證 3D 模型是否使用桌面端的 `scale (0.75)` 和 `position ([0, -4.25, -1.5])` 進行渲染。
- [ ] **移動端視圖驗證**：
    - 在瀏覽器視窗寬度小於或等於 500px 時 (或使用瀏覽器開發者工具模擬行動裝置)，驗證 3D 模型是否使用移動端的 `scale (0.55)` 和 `position ([0, -3, -1.7])` 進行渲染。
- [ ] **視窗大小動態調整驗證**：
    - 手動拖曳調整瀏覽器視窗寬度，使其在 500px 的臨界點來回切換。驗證 3D 模型是否能夠即時、正確地根據視窗寬度切換其 `scale` 和 `position`。