### PR TITLE
新增 showcase side project 的部分，搭配 GSAP，目前先用 mock data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Hero from './layout/Hero'
 import PC from './layout/Info'
+import ShowcaseSection from './layout/ShowcaseSection'
 
 const App: React.FC = () => {
   return (
@@ -8,6 +9,7 @@ const App: React.FC = () => {
       <div className="hero-bg">
         <PC />
         <Hero />
+        <ShowcaseSection />
       </div>
     </>
   )

--- a/src/layout/ShowcaseSection.tsx
+++ b/src/layout/ShowcaseSection.tsx
@@ -1,0 +1,78 @@
+import { useRef } from "react"
+import { gsap } from "gsap"
+import { ScrollTrigger } from "gsap/ScrollTrigger"
+import { useGSAP } from "@gsap/react"
+
+gsap.registerPlugin(ScrollTrigger)
+
+const ShowcaseSection = () => {
+  const sectionRef = useRef(null)
+  const project1Ref = useRef(null)
+  const project2Ref = useRef(null)
+  const project3Ref = useRef(null)
+
+  useGSAP(() => {
+    const projects = [project1Ref.current, project2Ref.current, project3Ref.current]
+
+    projects.forEach((card, index) => {
+      gsap.fromTo(
+        card, 
+        { y: 50, opacity: 0 },
+        {
+          y: 0, opacity: 1, duration: 1, delay: (index + 1) * 0.3, scrollTrigger: {
+            trigger: card,
+            start: "top bottom-=100",
+          }
+        }
+      )
+    })
+
+    gsap.fromTo(
+      sectionRef.current,
+      { opacity: 0 },
+      { opacity: 1, duration: 1.5 }
+    )
+  }, [])
+
+  return (
+    <>
+      <section id="work" ref={sectionRef} className="app-showcase">
+        <div className="w-full">
+          <div className="showcaselayout">
+            {/* left side */}
+            <div className="first-project-wrapper" ref={project1Ref}>
+              <div className="image-wrapper">
+                <img src="/images/project1.png" alt="project1" />
+              </div>
+              <div className="text-content">
+                <h2>
+                  On-Demand Rides Made Simple with a Powerful, User-Friendly App called Ryde
+                </h2>
+                <p className="text-white-50 md:text-xl">
+                  An app built with React Native, Expo, & TailwindCSS for a fast, user-friendly experience.
+                </p>
+              </div>
+            </div>
+            {/* right side */}
+            <div className="project-list-wrapper overflow-hidden">
+              <div className="project" ref={project2Ref}>
+                <div className="image-wrapper bg-[#ffefdb]">
+                  <img src="/images/project2.png" alt="project2" />
+                </div>
+                <h2>Library Management Platform</h2>
+              </div>
+              <div className="project" ref={project3Ref}>
+                <div className="image-wrapper bg-[#ffe7db]">
+                  <img src="/images/project3.png" alt="project3" />
+                </div>
+                <h2>YC Directory - A Startup Showcase App</h2>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}
+
+export default ShowcaseSection


### PR DESCRIPTION
## 背景描述 (Why)

此 PR 的主要目的是在作品集網站中新增一個「Side Project 展示」區塊。目前網站缺乏一個專門的區域來呈現個人的專案作品，此功能的新增可以更完整地展示開發者的技能與實務經驗，但目前先使用 Mock Data，後續再進行更改。

## 實作方法 (How)

- **新組件建立**: 創建了一個新的 React 組件 `ShowcaseSection.tsx` 於 `src/layout/` 路徑下，專門負責渲染此展示區塊的內容與佈局。
- **內容結構**: `ShowcaseSection` 內部設計為包含一個主要專案（左側）和兩個次要專案列表（右側）的結構。目前所有專案內容（圖片、標題、描述）均使用 Mock Data 填充。
- **動畫效果**:
    - 引入 `gsap` 函式庫及其 `ScrollTrigger` 和 `@gsap/react` 套件來實現動畫效果。
    - 對整個 `ShowcaseSection` 區塊應用了初始淡入（opacity 從 0 到 1）的動畫。
    - 對每個專案卡片（`project1Ref`, `project2Ref`, `project3Ref`）應用了滾動觸發的動畫：當卡片滾動到視窗底部特定位置 (`start: "top bottom-=100"`) 時，卡片會從下方輕微位移（y: 50, opacity: 0）並淡入（y: 0, opacity: 1），且每個卡片有微小的延遲 (`delay: (index + 1) * 0.3`) 以產生交錯效果。
    - 使用 `useRef` 獲取 DOM 元素的參照以供 GSAP 操作。
- **組件整合**: 新的 `ShowcaseSection` 組件被引入到主要的 `App.tsx` 中並進行渲染，成為應用程式佈局的一部分。

## 實際變更（做了什麼）

- **新增 `ShowcaseSection` 組件 (`src/layout/ShowcaseSection.tsx`)**
    - 開發了一個全新的 React 組件用於展示個人專案。
    - 組件包含專案圖片、標題和描述，目前使用 Mock Data。
    - 設計了左右佈局，左側為主要專案，右側為其他專案列表。
- **整合 GSAP 動畫**
    - 為整個展示區塊添加了頁面載入時的淡入動畫。
    - 為每個專案卡片添加了基於滾動觸發的進入動畫 (y 軸位移與透明度變化)，提升使用者互動體驗。
    - 在組件中註冊了 `ScrollTrigger` 插件。
- **於 `App.tsx` 中整合新組件**
    - 在主應用程式檔案 `App.tsx` 中引入並渲染了 `ShowcaseSection` 組件，使其成為頁面的一部分。

### 測試驗證

- [ ] **區塊渲染驗證**:
    - 確認 `ShowcaseSection` 在 `App.tsx` 中被正確引入並顯示在預期位置。
- [ ] **內容顯示驗證**:
    - 確認 Mock Data 中的專案圖片、標題和描述都已正確顯示在相應的專案卡片中。
- [ ] **GSAP 動畫驗證**:
    - **整體區塊淡入**: 驗證頁面加載/滾動到該區塊時，整個 `ShowcaseSection` 是否有平滑的淡入效果。
    - **專案卡片滾動觸發動畫**: 驗證當頁面向下滾動，各個專案卡片進入視窗可見範圍時，是否觸發了預設的 y 軸位移和淡入動畫，並且動畫效果流暢、延遲符合預期。
- [ ] **響應式佈局初步檢視**:
    - (雖然本次未明確提及響應式調整) 初步檢視在不同螢幕寬度下，該區塊的基本佈局是否會嚴重跑版 (作為後續優化的參考)。

## 補充說明

- 目前 `ShowcaseSection` 中的所有專案內容均為 Mock Data，後續需要開發功能以串接真實的專案數據來源 (例如 CMS 或本地 JSON 檔案)。
