### PR TITLE
增強 Email Button 三階段互動體驗

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 # Environment variables
 .env
+
+# claude code
+CLAUDE.md

--- a/src/layout/Contact.tsx
+++ b/src/layout/Contact.tsx
@@ -5,13 +5,15 @@ import emailjs from "@emailjs/browser"
 import TitleHeader from "../components/TitleHeader"
 import ContactExperience from "../components/Models/contact/ContactExperience"
 
+type ButtonState = 'ready' | 'loading' | 'success'
+
 const Contact = () => {
   const serviceId = import.meta.env.VITE_APP_EMAILJS_SERVICE_ID
   const templateId = import.meta.env.VITE_APP_EMAILJS_TEMPLATE_ID
   const publicKey = import.meta.env.VITE_APP_EMAILJS_PUBLIC_KEY
 
   const formRef = useRef<HTMLFormElement>(null)
-  const [loading, setLoading] = useState(false)
+  const [buttonState, setButtonState] = useState<ButtonState>('ready')
   const [form, setForm] = useState({
     name: "",
     email: "",
@@ -25,7 +27,7 @@ const Contact = () => {
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
-    setLoading(true)
+    setButtonState('loading')
 
     if (!formRef.current) return
 
@@ -37,12 +39,53 @@ const Contact = () => {
         publicKey
       )
 
-      // Reset form and stop loading
+      // Show success state and keep it
+      setButtonState('success')
       setForm({ name: "", email: "", message: "" })
     } catch (error) {
-      console.error("EmailJS Error:", error) // Optional: show toast
-    } finally {
-      setLoading(false) // Always stop loading, even on error
+      console.error("EmailJS Error:", error)
+      setButtonState('ready') // Reset on error
+    }
+  }
+
+  const renderButtonContent = () => {
+    switch (buttonState) {
+      case 'loading':
+        return (
+          <div className="flex-center w-full h-full">
+            <div className="inline-flex items-center gap-2 text-white">
+              <div className="animate-spin rounded-full h-4 w-4 border-2 border-white border-t-transparent"></div>
+              <span>Sending...</span>
+            </div>
+          </div>
+        )
+      case 'success':
+        return (
+          <div className="flex-center w-full h-full">
+            <svg 
+              className="w-8 h-8 animate-bounce" 
+              xmlns="http://www.w3.org/2000/svg" 
+              x="0px" 
+              y="0px" 
+              width="100" 
+              height="100" 
+              viewBox="0 0 48 48"
+            >
+              <path fill="#4caf50" d="M44,24c0,11-9,20-20,20S4,35,4,24S13,4,24,4S44,13,44,24z"></path>
+              <path fill="#ffffff" d="M34.6,14.6L21,28.2l-5.6-5.6l-2.8,2.8l8.4,8.4l16.4-16.4L34.6,14.6z"></path>
+            </svg>
+          </div>
+        )
+      default: // ready
+        return (
+          <>
+            <div className="bg-circle" />
+            <p className="text">Send Mail</p>
+            <div className="arrow-wrapper">
+              <img src="/images/arrow-down.svg" alt="arrow" />
+            </div>
+          </>
+        )
     }
   }
 
@@ -71,6 +114,7 @@ const Contact = () => {
                     onChange={handleChange}
                     placeholder="What's your good name?"
                     required
+                    disabled={buttonState !== 'ready'}
                   />
                 </div>
 
@@ -84,6 +128,7 @@ const Contact = () => {
                     onChange={handleChange}
                     placeholder="What's your email address?"
                     required
+                    disabled={buttonState !== 'ready'}
                   />
                 </div>
 
@@ -97,18 +142,27 @@ const Contact = () => {
                     placeholder="How can I help you?"
                     rows={5}
                     required
+                    disabled={buttonState !== 'ready'}
                   />
                 </div>
 
-                <button type="submit">
-                  <div className="cta-button group">
-                    <div className="bg-circle" />
-                    <p className="text">
-                      {loading ? "Sending..." : "Send Mail"}
-                    </p>
-                    <div className="arrow-wrapper">
-                      <img src="/images/arrow-down.svg" alt="arrow" />
-                    </div>
+                <button 
+                  type="submit"
+                  disabled={buttonState === 'loading' || buttonState === 'success'}
+                  className={`transition-all duration-300 ${
+                    buttonState === 'loading' || buttonState === 'success' 
+                      ? 'cursor-not-allowed' 
+                      : 'cursor-pointer'
+                  }`}
+                >
+                  <div className={`cta-button ${
+                    buttonState === 'ready' ? 'group' : ''
+                  } ${
+                    buttonState === 'success' 
+                      ? 'bg-green-500/20 border-green-400' 
+                      : ''
+                  }`}>
+                    {renderButtonContent()}
                   </div>
                 </button>
               </form>


### PR DESCRIPTION
## 背景描述 (Why)

目前的聯繫表單（Contact Form）在用戶點擊發送按鈕後，缺乏明確的互動反饋。舊的實作僅將按鈕文字變更為 "Sending..."，用戶無法直觀地確認郵件是否發送成功，這可能導致用戶體驗上的不確定性。

為了提升用戶體驗，本次變更旨在為 Email 發送按鈕導入一個清晰的三階段互動體驗：預設（Ready）、發送中（Loading）和成功（Success），為用戶提供即時且明確的視覺反饋。

## 實作方法 (How)

為實現上述目標，我們採用了以下方法：

1.  **引入狀態機 (State Machine)**：使用 React 的 `useState` Hook 將原先的布林值 `loading` 狀態，重構成一個更具描述性的 `buttonState` 狀態 (型別為 `'ready' | 'loading' | 'success'`)。這使得組件的狀態管理更為清晰和可擴展。

2.  **條件渲染 (Conditional Rendering)**：創建了一個新的輔助函式 `renderButtonContent`，根據當前的 `buttonState` 來動態渲染按鈕的內容。
    - `loading` 狀態：顯示一個動畫加載指示器 (spinner) 和 "Sending..." 文字。
    - `success` 狀態：顯示一個動畫的成功打勾圖示 (SVG)，給予用戶正向的確認反饋。
    - `ready` 狀態：顯示預設的 "Send Mail" 文字與圖示。

3.  **禁用互動元素**：在 `loading` 和 `success` 狀態下，禁用 (disable) 表單的所有輸入框和提交按鈕，以防止用戶在處理過程中或成功後進行重複提交或修改。

4.  **動態樣式**：利用 Tailwind CSS，根據 `buttonState` 為按鈕添加動態的 class，例如在成功時改變按鈕的背景與邊框顏色，以增強視覺效果。

## 實際變更（做了什麼）

- [x] **重構按鈕狀態管理**：將 `useState(false)` 的布林狀態替換為一個管理 `'ready'`, `'loading'`, `'success'` 三種狀態的狀態機。
- [x] **實現三階段按鈕 UI**：為按鈕的三種狀態設計了不同的視覺呈現，提升了互動的直觀性。
- [x] **增強用戶操作反饋**：在提交過程及成功後，禁用表單輸入，防止無效操作，使流程更穩健。
- [x] **優化程式碼結構**：將按鈕的渲染邏輯抽離至獨立的 `renderButtonContent` 函式，提高了程式碼的可讀性和可維護性。
- [x] **更新 .gitignore**：新增 `CLAUDE.md` 至忽略清單。

### 測試驗證

- [x] **成功路徑**：完整填寫表單後點擊發送，驗證按鈕狀態依序切換為 `Ready` -> `Loading` (顯示 spinner) -> `Success` (顯示打勾圖示)，且表單在 Loading 和 Success 狀態下被禁用。
- [x] **錯誤處理**：在 EmailJS 模擬發送失敗的場景下，驗證按鈕從 `Loading` 狀態會自動回復到 `Ready` 狀態，且表單重新變為可用，以便用戶重試。
- [x] **輸入驗證**：在未填寫必填欄位時點擊發送，驗證瀏覽器自身的 `required` 驗證功能正常觸發，且按鈕狀態保持為 `Ready`。

## 補充說明

本次變更引入的 `success` 狀態會一直持續，直到用戶刷新或離開頁面。未來的改進方向可以考慮加入一個計時器，在顯示成功圖示幾秒後，自動將按鈕重置回 `ready` 狀態。

## 相關連結

fix #14 